### PR TITLE
Imp. basic trie apis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.17
 
 require go.etcd.io/etcd/client/v3 v3.5.2
 
+require github.com/go-zookeeper/zk v1.0.2
+
 require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-zookeeper/zk v1.0.2 h1:4mx0EYENAdX/B/rbunjlt5+4RTA/a9SMHBRuSKdGxPM=
+github.com/go-zookeeper/zk v1.0.2/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,0 +1,6 @@
+package pkg
+
+const (
+	ZkAddr          = "localhost:2181"
+	TagNameTriePath = "/TagNameTrie"
+)

--- a/pkg/zk_client.go
+++ b/pkg/zk_client.go
@@ -1,0 +1,224 @@
+package pkg
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-zookeeper/zk"
+)
+
+const endOfWordNode = "/eow"
+
+// ConnectZk sets up a zookeeper connection
+func ConnectZk(zkAddr string) (*zk.Conn, error) {
+	conn, _, err := zk.Connect([]string{zkAddr}, 1*time.Second)
+	return conn, err
+}
+
+func InitTagNameTriePath(zkConn *zk.Conn) (err error) {
+	exists, _, err := zkConn.Exists(TagNameTriePath)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		_, err = zkConn.Create(TagNameTriePath, nil, 0, zk.WorldACL(zk.PermAll))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type ZkClient struct {
+	zkConn *zk.Conn
+}
+
+func CreateZkClient() (*ZkClient, error) {
+	zkConn, err := ConnectZk(ZkAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &ZkClient{
+		zkConn: zkConn,
+	}
+
+	rootlock, err := CreateDistLock("", zkConn)
+	if err != nil {
+		return nil, err
+	}
+	rootlock.Acquire()
+	InitTagNameTriePath(zkConn)
+	rootlock.Release()
+
+	return client, nil
+}
+
+func (zc *ZkClient) AddTagName(tagName string) error {
+	parent := TagNameTriePath
+	parentLock, err := CreateDistLock(parent, zc.zkConn)
+	if err != nil {
+		return err
+	}
+	parentLock.Acquire()
+
+	for i := 0; i < len(tagName); i++ {
+		character := tagName[i]
+		curPath := parent + fmt.Sprintf("/%c", character)
+
+		exists, _, err := zc.zkConn.Exists(curPath)
+		if err != nil {
+			parentLock.Release()
+			return err
+		}
+		if !exists {
+			_, err = zc.zkConn.Create(curPath, nil, 0, zk.WorldACL(zk.PermAll))
+			if err != nil {
+				parentLock.Release()
+				return err
+			}
+		}
+
+		childLock, err := CreateDistLock(curPath, zc.zkConn)
+		if err != nil {
+			parentLock.Release()
+			return err
+		}
+		err = childLock.Acquire()
+		if err != nil {
+			parentLock.Release()
+			return err
+		}
+		err = parentLock.Release()
+		if err != nil {
+			childLock.Release()
+			return err
+		}
+
+		parent = curPath
+		parentLock = childLock
+	}
+
+	defer parentLock.Release()
+
+	exists, _, err := zc.zkConn.Exists(parent + endOfWordNode)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		_, err = zc.zkConn.Create(parent+endOfWordNode, nil, 0, zk.WorldACL(zk.PermAll))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (zc *ZkClient) SearchTagName(regexp string) (results []string, err error) {
+	parent := TagNameTriePath
+	parentLock, err := CreateDistLock(parent, zc.zkConn)
+	if err != nil {
+		return nil, err
+	}
+	parentLock.Acquire()
+
+	for i, character := range regexp {
+		if character != '*' {
+			curPath := parent + fmt.Sprintf("/%c", character)
+			exists, _, err := zc.zkConn.Exists(curPath)
+			if err != nil {
+				parentLock.Release()
+				return nil, err
+			}
+
+			if !exists {
+				return results, nil
+			}
+
+			childLock, err := CreateDistLock(curPath, zc.zkConn)
+			if err != nil {
+				parentLock.Release()
+				return nil, err
+			}
+
+			err = childLock.Acquire()
+			if err != nil {
+				parentLock.Release()
+				return nil, err
+			}
+			err = parentLock.Release()
+			if err != nil {
+				childLock.Release()
+				return nil, err
+			}
+
+			parent = curPath
+			parentLock = childLock
+
+		} else {
+			if i != len(regexp)-1 {
+				return results, errors.New("* wildcard needs to be the last character in regexp")
+			}
+			return zc.SearchAllTagName(parent, parentLock)
+		}
+	}
+
+	defer parentLock.Release()
+	exists, _, err := zc.zkConn.Exists(parent + endOfWordNode)
+	if exists {
+		results = append(results, regexp)
+	}
+
+	return results, err
+}
+
+func (zc *ZkClient) SearchAllTagName(parent string, parentLock *DistLock) (results []string, err error) {
+	if parentLock == nil {
+		parentLock, err = CreateDistLock(parent, zc.zkConn)
+		if err != nil {
+			return results, err
+		}
+		parentLock.Acquire()
+	}
+
+	defer parentLock.Release()
+
+	children, _, err := zc.zkConn.Children(parent)
+	if err != nil {
+		return results, err
+	}
+
+	exists, _, err := zc.zkConn.Exists(parent + endOfWordNode)
+	if err != nil {
+		return results, err
+	}
+
+	if exists {
+		results = append(results, getTagNameFromPath(parent))
+	}
+
+	for _, child := range children {
+		// TODO: ignore /lock and /eow
+		if child == "lock" || child == "eow" {
+			continue
+		}
+		childResults, err := zc.SearchAllTagName(fmt.Sprintf("%s/%s", parent, child), nil)
+		if err != nil {
+			return results, err
+		}
+
+		results = append(results, childResults...)
+	}
+
+	return results, nil
+}
+
+func getTagNameFromPath(path string) string {
+	return strings.Join(strings.Split(path, "/")[2:], "")
+}

--- a/pkg/zk_dist_lock.go
+++ b/pkg/zk_dist_lock.go
@@ -1,0 +1,138 @@
+package pkg
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-zookeeper/zk"
+)
+
+const lockParent = "/lock"
+const lockPrefix = "/lock-"
+
+// DistLock is a distributed lock that can be initialized with a root Zookeeper
+// path and a Zookeeper connection. It can write, via the Zookeeper connection,
+// to the root path.
+//
+// CounterClients use DistLock to acquire control of certain paths in Zookeeper
+// (most importantly /counter) and prevents other CounterClients from also modifying
+// the data at t path concurrently.
+type DistLock struct {
+	root   string // root zk path in which the lock is placed
+	path   string // full zk path of the lock
+	zkConn *zk.Conn
+}
+
+// CreateDistLock creates a distributed lock
+func CreateDistLock(root string, zkConn *zk.Conn) (*DistLock, error) {
+	_, err := zkConn.Create(fmt.Sprintf("%s%s", root, lockParent), nil, 0, zk.WorldACL(zk.PermAll))
+	if err != nil && err.Error() != "zk: node already exists" {
+		fmt.Println(err)
+		return nil, err
+	}
+
+	dlock := &DistLock{
+		root:   root,
+		path:   "",
+		zkConn: zkConn,
+	}
+	return dlock, nil
+}
+
+// Acquire tries acquire a distributed lock from Zookeeper. If another client already acquired the lock,
+// it waits until the lock is released.
+//
+// The basic recipe is as follows:
+// 1. Call Create() with a pathname of "<lock-root>/lock-" and the sequence and ephemeral flags set.
+// 2. Call Children() on the lock node without setting the watch flag.
+// 3. If the pathname created in step 1 has the lowest sequence number suffix,
+//    the client has the lock and should exit the protocol.
+// 4. The client calls Exists() with the watch flag set on the path in the lock directory
+//    with the next lowest sequence number
+// 5. if Exists() returns false, go to step 2.
+//    Otherwise, wait for a notification for the pathname from the previous step before going to step 2.
+func (d *DistLock) Acquire() (err error) {
+	if d.path != "" {
+		return errors.New("the lock is already acquired")
+	}
+
+	// 1. Call Create() with a pathname of "<lock-root>/lock-" and the sequence and ephemeral flags set.
+	curPath, err := d.zkConn.Create(
+		fmt.Sprintf("%s%s%s", d.root, lockParent, lockPrefix),
+		nil,
+		zk.FlagSequence|zk.FlagEphemeral,
+		zk.WorldACL(zk.PermAll),
+	)
+	if err != nil {
+		return err
+	}
+
+	d.path = curPath
+	curSeq, err := getSeqNumFromZkPath(d.path)
+	if err != nil {
+		return err
+	}
+	for {
+		// 2. Call Children() on the lock node without setting the watch flag.
+		children, _, err := d.zkConn.Children(fmt.Sprintf("%s%s", d.root, lockParent))
+		if err != nil {
+			return err
+		}
+
+		minSeq := curSeq
+		for _, child := range children {
+			childSeq, err := getSeqNumFromZkPath(child)
+			if err != nil {
+				return err
+			}
+
+			if childSeq < minSeq {
+				minSeq = childSeq
+			}
+		}
+
+		// 3. If the pathname created in step 1 has the lowest sequence number suffix,
+		//    the client has the lock and should exit the protocol.
+		if curSeq == minSeq {
+			return nil
+		}
+
+		// 4. The client calls Exists() with the watch flag set on the path in the lock directory
+		//    with the next lowest sequence number
+		exists, _, ech, err := d.zkConn.ExistsW(createZkPathFromSeqNum(fmt.Sprintf("%s%s%s", d.root, lockParent, lockPrefix), minSeq))
+		if err != nil {
+			return err
+		}
+
+		// 5. if Exists() returns false, go to step 2.
+		//    Otherwise, wait for a notification for the pathname from the previous step before going to step 2.
+		if exists {
+			<-ech
+		}
+	}
+}
+
+// The unlock protocol is very simple: clients wishing to release a lock simply delete the node they created in step 1.
+func (d *DistLock) Release() (err error) {
+	if d.path == "" {
+		return errors.New("is not locked in the first place")
+	}
+
+	err = d.zkConn.Delete(d.path, -1)
+	if err != nil {
+		return err
+	}
+
+	d.path = ""
+	return nil
+}
+
+func getSeqNumFromZkPath(path string) (int, error) {
+	return strconv.Atoi(strings.Split(path, "-")[1])
+}
+
+func createZkPathFromSeqNum(root string, seqId int) string {
+	return root + fmt.Sprintf("%010d", seqId)
+}

--- a/test/zk_test.go
+++ b/test/zk_test.go
@@ -1,0 +1,92 @@
+package test
+
+import (
+	"sync"
+	"testing"
+
+	zk "distributed-metadata-index/pkg"
+)
+
+// CleanupZk ensures that tests can be run one after another by clearing
+// the Zookeeper directory after each test.
+func CleanupZk() {
+	zkConn, _ := zk.ConnectZk(zk.ZkAddr)
+	zkConn.Delete(zk.TagNameTriePath, -1)
+	children, _, _ := zkConn.Children(zk.TagNameTriePath)
+	for _, c := range children {
+		zkConn.Delete(c, -1)
+	}
+}
+
+func TestBasic(t *testing.T) {
+	client, _ := zk.CreateZkClient()
+
+	err := client.AddTagName("abc")
+	if err != nil {
+		t.Errorf("error while AddTagName, err: %v\n", err)
+	}
+	err = client.AddTagName("aiden")
+	if err != nil {
+		t.Errorf("error while AddTagName, err: %v\n", err)
+	}
+	err = client.AddTagName("efg")
+	if err != nil {
+		t.Errorf("error while AddTagName, err: %v\n", err)
+	}
+
+	results, err := client.SearchTagName("aiden")
+	if err != nil {
+		t.Errorf("error while SearchTagName, err: %v\n", err)
+	}
+
+	if len(results) != 1 || results[0] != "aiden" {
+		t.Errorf("wrong result, expect: ['aiden'], actual: %v\n", results)
+	}
+
+	t.Cleanup(CleanupZk)
+}
+
+func TestConcurrentAdd(t *testing.T) {
+	numClients := 10
+	tagNames := [10]string{"abc", "acd", "bde", "bdf", "aba", "abc", "bac", "cef", "caf", "def"}
+	var wg sync.WaitGroup
+	for i := 0; i < numClients; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			zc, err := zk.CreateZkClient()
+			if err != nil {
+				t.Error(err)
+			}
+			err = zc.AddTagName(tagNames[idx])
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	zc, _ := zk.CreateZkClient()
+	allTagNames, err := zc.SearchAllTagName(zk.TagNameTriePath, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(allTagNames) != 9 {
+		t.Errorf("number of all tags is incorrect, expect: 9, acutal: %v\n", len(allTagNames))
+	}
+
+	for _, actualTag := range tagNames {
+		exists := false
+		for _, tag := range allTagNames {
+			if actualTag == tag {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			t.Errorf("cannot find %v in the trie\n", actualTag)
+		}
+	}
+
+	t.Cleanup(CleanupZk)
+}


### PR DESCRIPTION
Implement a tag-name storage in the Trie data structure with zookeeper.

### **Usage**
**Spin up a zookeeper instance**
Install docker and run `docker run --rm -p 2181:2181 zookeeper` in terminal

** Install go-zookeeper package
run `go mod tidy` in terminal

**In your code**
```go
client, err := CreateZkClient()
err = client.AddTagName("cpu")
err = client.AddTagName("cpa")
results, err := client.SearchTagName("cp*")  // results = ["cpa", cpu"]
```

Keep in mind that we currently only support a *-wildcard at the end of the search string





